### PR TITLE
react-icons: update forwardRef types

### DIFF
--- a/packages/react-icons/convert.js
+++ b/packages/react-icons/convert.js
@@ -93,7 +93,7 @@ function processFolder(srcPath, destPath, resizable) {
   var svgrOpts = {
     template: fileTemplate,
     expandProps: 'start', // HTML attributes/props for things like accessibility can be passed in, and will be expanded on the svg object at the start of the object
-    svgProps: { className: '{className}', ref: '{ref}'}, // In order to provide styling, className will be used
+    svgProps: { ref: '{ref}'}, // In order to provide styling, className will be used
     replaceAttrValues: { '#212121': '{primaryFill}' }, // We are designating primaryFill as the primary color for filling. If not provided, it defaults to null.
     typescript: true,
     icon: true
@@ -102,7 +102,7 @@ function processFolder(srcPath, destPath, resizable) {
   var svgrOptsSizedIcons = {
     template: fileTemplate,
     expandProps: 'start', // HTML attributes/props for things like accessibility can be passed in, and will be expanded on the svg object at the start of the object
-    svgProps: { className: '{className}', ref: '{ref}'}, // In order to provide styling, className will be used
+    svgProps: { ref: '{ref}'}, // In order to provide styling, className will be used
     replaceAttrValues: { '#212121': '{primaryFill}' }, // We are designating primaryFill as the primary color for filling. If not provided, it defaults to null.
     typescript: true
   }
@@ -135,8 +135,8 @@ function processFolder(srcPath, destPath, resizable) {
       var jsCode = 
 `
 
-const ${destFilename}Icon = React.forwardRef((props: FluentIconsProps, ref: React.LegacyRef<SVGSVGElement>) => {  
-  const { fill: primaryFill = 'currentColor', className } = props;
+const ${destFilename}Icon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<SVGSVGElement>) => {  
+  const { fill: primaryFill = 'currentColor' } = props;
   return ${jsxCode};
 })
 export const ${destFilename} = /*#__PURE__*/wrapIcon(/*#__PURE__*/${destFilename}Icon, '${destFilename}');

--- a/packages/react-icons/src/utils/wrapIcon.tsx
+++ b/packages/react-icons/src/utils/wrapIcon.tsx
@@ -2,8 +2,12 @@ import * as React from "react";
 import { FluentIconsProps } from "./FluentIconsProps.types";
 import { useIconState } from "./useIconState";
 
-const wrapIcon = (Icon: React.ForwardRefExoticComponent<React.SVGAttributes<SVGElement> & FluentIconsProps & React.RefAttributes<SVGElement>>, displayName?: string) => {
-    const WrappedIcon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<SVGElement>) => { 
+type IconWithRefProps = 
+    React.ForwardRefExoticComponent<FluentIconsProps & 
+    React.RefAttributes<SVGSVGElement>>;
+
+const wrapIcon = (Icon: IconWithRefProps, displayName?: string) => {
+    const WrappedIcon = React.forwardRef((props: FluentIconsProps, ref: React.Ref<SVGSVGElement>) => { 
         const state = useIconState(props);
         return <Icon ref={ref} {...state} />
     })


### PR DESCRIPTION
- Simplified the type for Icon in wrapIcon.tsx.
- Aligned on the SVGSVGElement type for <svg> JSX elements in wrapIcon.tsx and convert.js.
- Removed the "className" prop destructure in convert.js since props are spread anyway.